### PR TITLE
ci: scope push trigger to main to stop duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: CI
 
 on:
+  # Scope push to main only. PRs from same-repo branches already run via the
+  # pull_request event, so an unscoped push trigger ran every job twice and
+  # doubled Actions minutes. This keeps branch coverage (PR event) and main
+  # coverage (push event) without the overlap.
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
The workflow triggered on `push:` and `pull_request:` unscoped, so a PR from a same-repo branch fired both events and ran every job twice — doubling Actions minutes (visible on PR #1, where each check appeared twice).

This scopes the push trigger to `main`. Branch/PR coverage still comes from the `pull_request` event; post-merge coverage on `main` still comes from the `push` event. No overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)